### PR TITLE
Use `tomlkit` rather than `yq` to parse TOML data

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,6 @@
   "files.exclude": {
     "**/.git": true
   },
+  "python.defaultInterpreterPath": "/usr/bin/python",
   "shellcheck.useWorkspaceRootAsCwd": true
 }

--- a/README.md
+++ b/README.md
@@ -8,7 +8,16 @@ remotes, changing them to HTTPS as needed, then runs
 
 ### Installing manually
 
-Clone this repository to any directory you like.
+1. Make sure you have the following dependencies installed:
+
+    - `bash`
+    - `findutils`
+    - `git`
+    - `parallel`
+    - Python
+    - PyPI packages `dotty_dict` and `tomlkit`
+
+2. Clone this repository to any directory you like.
 
 ### Installing from the AUR
 

--- a/libexec/aur-pull.bash
+++ b/libexec/aur-pull.bash
@@ -10,7 +10,7 @@ function __aur_pull {
   parse_options "$@"
 
   if [[ -z "${basedir:-}" ]]; then
-    read_config_homedir_aware 'basedir' '.config.basedir' "$(pwd)"
+    read_config_homedir_aware 'basedir' 'config.basedir' "$(pwd)"
   fi
 
   if [[ -z "${remote:-}" ]]; then

--- a/libexec/constants.bash
+++ b/libexec/constants.bash
@@ -1,4 +1,8 @@
 export __GIT_DEFAULT_BRANCH='master'
 export __GIT_DEFAULT_REMOTE='origin'
+
+__PROJECT_ROOT="$(pwd)/$(dirname -- "${BASH_SOURCE[0]}")/.."
+export __PROJECT_ROOT
+
 export __REMOTE_URL_BASE='https://aur.archlinux.org'
 export __SETTINGS_FILE='aur-pull.toml'

--- a/libexec/print_setting.py
+++ b/libexec/print_setting.py
@@ -1,0 +1,23 @@
+#!/usr/bin/python
+"""
+Parses a TOML file for a setting given by dotted key and prints
+the result.
+
+If the file or setting doesn’t exist, print a default value.
+"""
+
+import os.path
+import sys
+
+from dotty_dict import dotty
+from tomlkit.toml_file import TOMLFile
+
+settings_path, dotted_key, default_value = sys.argv[1:]
+
+if os.path.exists(settings_path):
+    document = TOMLFile(settings_path).read()
+    value = dotty(document).get(dotted_key, default_value)
+else:
+    value = default_value
+
+print(value)

--- a/libexec/settings.bash
+++ b/libexec/settings.bash
@@ -1,14 +1,14 @@
 source libexec/constants.bash
 
 function read_config {
-  local default_value tomlq_filter variable_name
+  local default_value dotted_key variable_name
   variable_name="${1?}"
-  tomlq_filter="${2?}"
+  dotted_key="${2?}"
   default_value="${3?}"
 
   read -r -d '\n' "${variable_name?}" < <(
     _print_setting \
-      "${variable_name}" "${tomlq_filter}" "${default_value}"
+      "${variable_name}" "${dotted_key}" "${default_value}"
   ) || true
 }
 
@@ -16,14 +16,14 @@ export -f read_config
 
 
 function read_config_homedir_aware {
-  local default_value tomlq_filter variable_name
+  local default_value dotted_key variable_name
   variable_name="${1?}"
-  tomlq_filter="${2?}"
+  dotted_key="${2?}"
   default_value="${3?}"
 
   read -r -d '\n' "${variable_name?}" < <(
     _print_setting \
-      "${variable_name}" "${tomlq_filter}" "${default_value}" \
+      "${variable_name}" "${dotted_key}" "${default_value}" \
       | sed -e "s#^~/#${HOME}/#"
   ) || true
 }
@@ -32,12 +32,12 @@ export -f read_config_homedir_aware
 
 
 function _print_setting {
-  local default_value tomlq_filter variable_name
+  local default_value settings_path dotted_key variable_name
   variable_name="${1?}"
-  tomlq_filter="${2?}"
+  dotted_key="${2?}"
   default_value="${3?}"
+  settings_path="${XDG_CONFIG_HOME:-"${HOME}/.config"}/${__SETTINGS_FILE}"
 
-  tomlq -r --arg default_value "${default_value}" \
-    "${tomlq_filter} // \$default_value" \
-    "${XDG_CONFIG_HOME:-"${HOME}/.config"}/${__SETTINGS_FILE}"
+  python "${__PROJECT_ROOT}/libexec/print_setting.py" \
+    "${settings_path}" "${dotted_key}" "${default_value}"
 }


### PR DESCRIPTION
Depending on `yq` turns out less than ideal because it may conflict with
the `go-yq` package the user might have installed.

Use `tomlkit` instead of `yq` to work around that.

Closes #1.
Thanks to @averyfreeman for letting me know about the issue.